### PR TITLE
Refactor `innerJoin`

### DIFF
--- a/src/package/innerJoin/index.ts
+++ b/src/package/innerJoin/index.ts
@@ -1,6 +1,5 @@
 import { isArrayOfObject, isObject, isString } from "../../utils/type-check";
 import getObjDeepProp from "../../utils/get-obj-deep-prop";
-import { where } from "..";
 
 type InnerJoinFunction = (
   data: Object[],

--- a/src/package/innerJoin/index.ts
+++ b/src/package/innerJoin/index.ts
@@ -1,4 +1,4 @@
- import { isArrayOfObject, isObject, isString } from "../../utils/type-check";
+import { isArrayOfObject, isObject, isString } from "../../utils/type-check";
 import getObjDeepProp from "../../utils/get-obj-deep-prop";
 import { where } from "..";
 
@@ -27,12 +27,12 @@ const innerJoin: InnerJoinFunction = (
     return data;
   }
 
+  const getDataField = getObjDeepProp(dataFieldName);
+  const getOtherDataField = getObjDeepProp(otherDataFieldName);
+  const temp = otherData.reduce((p, n) => p.set(getOtherDataField(n), n), new Map());
+
   return data.map(item => {
-    const [otherDataItem] = where(
-      otherData,
-      { [otherDataFieldName]: getObjDeepProp(dataFieldName)(item) },
-      { deep: true }
-    );
+    const otherDataItem = temp.get(getDataField(item));
 
     if (isObject(otherDataItem)) {
       return { ...item, ...otherDataItem };

--- a/src/package/innerJoin/index.ts
+++ b/src/package/innerJoin/index.ts
@@ -28,7 +28,7 @@ const innerJoin: InnerJoinFunction = (
 
   const getDataField = getObjDeepProp(dataFieldName);
   const getOtherDataField = getObjDeepProp(otherDataFieldName);
-  const temp = otherData.reduce((p, n) => p.set(getOtherDataField(n), n), new Map());
+  const temp = otherData.reduce<Map<any, object>>((p, n) => p.set(getOtherDataField(n), n), new Map());
 
   return data.map(item => {
     const otherDataItem = temp.get(getDataField(item));


### PR DESCRIPTION
Use a `Map` to cache the other data, instead of a calling `where` for each item of the initial data array.